### PR TITLE
Adjust 'on' spec for build actions 

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -1,28 +1,33 @@
 name: backend build
 
 on:
-  push:
-  pull_request:
-    branches: [ "main" ]
+    push:
+        branches:
+            - "**"
+    pull_request:
+        branches:
+            - "**"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./backend
+    build:
+        runs-on: ubuntu-latest
+        if: github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        defaults:
+            run:
+                working-directory: ./backend
 
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x]
+        strategy:
+            matrix:
+                node-version: [16.x, 18.x]
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: ./backend/package-lock.json
-    - run: npm ci
-    - run: npm run build
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+                  cache-dependency-path: ./backend/package-lock.json
+            - run: npm ci
+            - run: npm run build

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,28 +1,33 @@
 name: frontend build
 
 on:
-  push:
-  pull_request:
-    branches: [ "main" ]
+    push:
+        branches:
+            - "**"
+    pull_request:
+        branches:
+            - "**"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
+    build:
+        runs-on: ubuntu-latest
+        if: github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        defaults:
+            run:
+                working-directory: ./frontend
 
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x]
+        strategy:
+            matrix:
+                node-version: [16.x, 18.x]
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: ./frontend/package-lock.json
-    - run: npm ci
-    - run: npm run build
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+                  cache-dependency-path: ./frontend/package-lock.json
+            - run: npm ci
+            - run: npm run build


### PR DESCRIPTION
Adjust 'on' spec for build actions to not run twice when pushed with an opened PR - 'pull_request' events only start the action now if it comes from a forked repo.